### PR TITLE
feat: add hosts and postures endpoints with CRUD operations

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,9 +10,11 @@ import (
 	"github.com/lbrlabs/tacl/pkg/acl/autoapprovers"
 	"github.com/lbrlabs/tacl/pkg/acl/derpmap"
 	"github.com/lbrlabs/tacl/pkg/acl/groups"
+	"github.com/lbrlabs/tacl/pkg/acl/hosts"
 	nodeattrs "github.com/lbrlabs/tacl/pkg/acl/nodeattributes"
 	"github.com/lbrlabs/tacl/pkg/acl/settings"
 	"github.com/lbrlabs/tacl/pkg/acl/ssh"
+	"github.com/lbrlabs/tacl/pkg/acl/postures"
 	"github.com/lbrlabs/tacl/pkg/common"
 	"go.uber.org/zap"
 )
@@ -63,6 +65,9 @@ func main() {
 	ssh.RegisterRoutes(r, state)
 	settings.RegisterRoutes(r, state)
 	nodeattrs.RegisterRoutes(r, state)
+	hosts.RegisterRoutes(r, state)
+	postures.RegisterRoutes(r, state)
+
 
 	// Optional: debug route to dump the entire state
 	r.GET("/state", func(c *gin.Context) {

--- a/pkg/acl/hosts/hosts.go
+++ b/pkg/acl/hosts/hosts.go
@@ -1,0 +1,235 @@
+package hosts
+
+import (
+	"encoding/json"
+	"github.com/gin-gonic/gin"
+	"github.com/lbrlabs/tacl/pkg/common"
+	"net/http"
+)
+
+// Host is the user-facing structure.
+// The final stored JSON is map["hostname"] => "ipString".
+type Host struct {
+	Name string `json:"name" binding:"required"`
+	IP   string `json:"ip"   binding:"required"`
+}
+
+// RegisterRoutes wires up the /hosts endpoints.
+// The final JSON in state.Data["hosts"] is map["Name"] => "IP/CIDR".
+func RegisterRoutes(r *gin.Engine, state *common.State) {
+	h := r.Group("/hosts")
+	{
+		// GET /hosts => list all
+		h.GET("", func(c *gin.Context) {
+			listHosts(c, state)
+		})
+
+		// GET /hosts/:name => get one host
+		h.GET("/:name", func(c *gin.Context) {
+			getHostByName(c, state)
+		})
+
+		// POST /hosts => create
+		h.POST("", func(c *gin.Context) {
+			createHost(c, state)
+		})
+
+		// PUT /hosts => update
+		h.PUT("", func(c *gin.Context) {
+			updateHost(c, state)
+		})
+
+		// DELETE /hosts => delete
+		h.DELETE("", func(c *gin.Context) {
+			deleteHost(c, state)
+		})
+	}
+}
+
+// listHosts => GET /hosts
+// Returns an array of Host objects. The final data is a map, so we convert it back to an array.
+func listHosts(c *gin.Context, state *common.State) {
+	hosts, err := getHostsFromState(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse hosts"})
+		return
+	}
+	c.JSON(http.StatusOK, hosts)
+}
+
+// getHostByName => GET /hosts/:name
+func getHostByName(c *gin.Context, state *common.State) {
+	name := c.Param("name")
+
+	hosts, err := getHostsFromState(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse hosts"})
+		return
+	}
+
+	for _, h := range hosts {
+		if h.Name == name {
+			c.JSON(http.StatusOK, h)
+			return
+		}
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "Host not found"})
+}
+
+// createHost => POST /hosts
+// Returns 409 Conflict if the name already exists.
+func createHost(c *gin.Context, state *common.State) {
+	var newHost Host
+	if err := c.ShouldBindJSON(&newHost); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if newHost.Name == "" || newHost.IP == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing 'name' or 'ip' field"})
+		return
+	}
+
+	hosts, err := getHostsFromState(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse hosts"})
+		return
+	}
+
+	// Check for conflict
+	for _, h := range hosts {
+		if h.Name == newHost.Name {
+			c.JSON(http.StatusConflict, gin.H{"error": "Host already exists"})
+			return
+		}
+	}
+
+	hosts = append(hosts, newHost)
+	if err := saveHosts(state, hosts); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save new host"})
+		return
+	}
+	c.JSON(http.StatusCreated, newHost)
+}
+
+// updateHost => PUT /hosts
+// Expects { "name": "...", "ip": "..." }
+func updateHost(c *gin.Context, state *common.State) {
+	var updated Host
+	if err := c.ShouldBindJSON(&updated); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if updated.Name == "" || updated.IP == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing 'name' or 'ip' field"})
+		return
+	}
+
+	hosts, err := getHostsFromState(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse hosts"})
+		return
+	}
+
+	found := false
+	for i, h := range hosts {
+		if h.Name == updated.Name {
+			hosts[i] = updated
+			found = true
+			break
+		}
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Host not found"})
+		return
+	}
+
+	if err := saveHosts(state, hosts); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update host"})
+		return
+	}
+	c.JSON(http.StatusOK, updated)
+}
+
+// deleteHost => DELETE /hosts
+// Expects JSON: { "name": "example-host-1" }
+func deleteHost(c *gin.Context, state *common.State) {
+	type request struct {
+		Name string `json:"name"`
+	}
+	var req request
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing 'name' field"})
+		return
+	}
+
+	hosts, err := getHostsFromState(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse hosts"})
+		return
+	}
+
+	found := false
+	for i, h := range hosts {
+		if h.Name == req.Name {
+			hosts = append(hosts[:i], hosts[i+1:]...)
+			found = true
+			break
+		}
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Host not found"})
+		return
+	}
+
+	if err := saveHosts(state, hosts); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save changes"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Host deleted"})
+}
+
+// -----------------------------------------------------------------------------
+// We want final JSON => "hosts": { "<Name>":"<IP>", ... }
+// But user sees array of Host {Name, IP}.
+//
+// getHostsFromState => read map => convert to []Host
+// saveHosts => convert []Host => map => store
+// -----------------------------------------------------------------------------
+
+func getHostsFromState(state *common.State) ([]Host, error) {
+	raw := state.GetValue("hosts")
+	if raw == nil {
+		return []Host{}, nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	// final stored data: map["Name"] => "IP"
+	var rawMap map[string]string
+	if err := json.Unmarshal(b, &rawMap); err != nil {
+		return nil, err
+	}
+
+	// Convert map => array
+	var out []Host
+	for name, ip := range rawMap {
+		out = append(out, Host{
+			Name: name,
+			IP:   ip,
+		})
+	}
+	return out, nil
+}
+
+func saveHosts(state *common.State, hosts []Host) error {
+	m := make(map[string]string)
+	for _, h := range hosts {
+		m[h.Name] = h.IP
+	}
+	return state.UpdateKeyAndSave("hosts", m)
+}

--- a/pkg/acl/postures/postures.go
+++ b/pkg/acl/postures/postures.go
@@ -1,0 +1,344 @@
+package postures
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/lbrlabs/tacl/pkg/common"
+)
+
+// Posture represents a named "posture" entry and its list of rules.
+// Example JSON when creating/updating:
+//
+//   {
+//     "name": "latestMac",
+//     "rules": [
+//       "node:os in ['macos']",
+//       "node:tsVersion >= '1.40'"
+//     ]
+//   }
+type Posture struct {
+	Name  string   `json:"name" binding:"required"`
+	Rules []string `json:"rules"`
+}
+
+// RegisterRoutes wires up /postures, including:
+// - Named posture CRUD (like /groups, /tagowners)
+// - Default posture GET/PUT/DELETE at /postures/default
+func RegisterRoutes(r *gin.Engine, state *common.State) {
+	p := r.Group("/postures")
+	{
+		// Entire list of named Posture + the current default
+		p.GET("", func(c *gin.Context) {
+			listAllPostures(c, state)
+		})
+
+		// Named posture CRUD
+		p.GET("/:name", func(c *gin.Context) {
+			name := c.Param("name")
+			if name == "default" {
+				// conflict with our default route
+				getDefaultPosture(c, state)
+			} else {
+				getPostureByName(c, state, name)
+			}
+		})
+		p.POST("", func(c *gin.Context) {
+			createPosture(c, state)
+		})
+		p.PUT("", func(c *gin.Context) {
+			updatePosture(c, state)
+		})
+		p.DELETE("", func(c *gin.Context) {
+			deletePosture(c, state)
+		})
+
+		// Default posture: GET/PUT/DELETE => /postures/default
+		p.GET("/default", func(c *gin.Context) {
+			getDefaultPosture(c, state)
+		})
+		p.PUT("/default", func(c *gin.Context) {
+			setDefaultPosture(c, state)
+		})
+		p.DELETE("/default", func(c *gin.Context) {
+			deleteDefaultPosture(c, state)
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Named Posture List
+// -----------------------------------------------------------------------------
+
+// listAllPostures => GET /postures
+// Returns a JSON object containing:
+// {
+//   "defaultSourcePosture": [...],
+//   "items": [
+//      { "name":"latestMac", "rules": [...] },
+//      ...
+//   ]
+// }
+func listAllPostures(c *gin.Context, state *common.State) {
+	postures, defaultPosture, err := getPosturesAndDefault(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"defaultSourcePosture": defaultPosture,
+		"items":                postures,
+	})
+}
+
+// getPostureByName => GET /postures/:name (when :name != "default")
+func getPostureByName(c *gin.Context, state *common.State, name string) {
+	postures, _, err := getPosturesAndDefault(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	for _, p := range postures {
+		if p.Name == name {
+			c.JSON(http.StatusOK, p)
+			return
+		}
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "Posture not found"})
+}
+
+// createPosture => POST /postures
+// 409 Conflict if the name already exists
+func createPosture(c *gin.Context, state *common.State) {
+	var newPosture Posture
+	if err := c.ShouldBindJSON(&newPosture); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if newPosture.Name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing 'name' field"})
+		return
+	}
+
+	postures, defaultPosture, err := getPosturesAndDefault(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Check for conflict
+	for _, p := range postures {
+		if p.Name == newPosture.Name {
+			c.JSON(http.StatusConflict, gin.H{"error": "Posture already exists"})
+			return
+		}
+	}
+
+	// Append & save
+	postures = append(postures, newPosture)
+	if err := savePosturesAndDefault(state, postures, defaultPosture); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save new posture"})
+		return
+	}
+	c.JSON(http.StatusCreated, newPosture)
+}
+
+// updatePosture => PUT /postures
+// Expects { "name": "...", "rules": [...] }
+func updatePosture(c *gin.Context, state *common.State) {
+	var updated Posture
+	if err := c.ShouldBindJSON(&updated); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if updated.Name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing 'name' field"})
+		return
+	}
+
+	postures, defaultPosture, err := getPosturesAndDefault(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	found := false
+	for i, p := range postures {
+		if p.Name == updated.Name {
+			postures[i] = updated
+			found = true
+			break
+		}
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Posture not found"})
+		return
+	}
+
+	if err := savePosturesAndDefault(state, postures, defaultPosture); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update posture"})
+		return
+	}
+	c.JSON(http.StatusOK, updated)
+}
+
+// deletePosture => DELETE /postures
+// Expects { "name": "latestMac" }
+func deletePosture(c *gin.Context, state *common.State) {
+	type request struct {
+		Name string `json:"name"`
+	}
+	var req request
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if req.Name == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing 'name' field"})
+		return
+	}
+
+	postures, defaultPosture, err := getPosturesAndDefault(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	found := false
+	for i, p := range postures {
+		if p.Name == req.Name {
+			postures = append(postures[:i], postures[i+1:]...)
+			found = true
+			break
+		}
+	}
+	if !found {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Posture not found"})
+		return
+	}
+
+	if err := savePosturesAndDefault(state, postures, defaultPosture); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save changes"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Posture deleted"})
+}
+
+// -----------------------------------------------------------------------------
+// DefaultSourcePosture (special "defaultSourcePosture" key in the map)
+// -----------------------------------------------------------------------------
+
+// getDefaultPosture => GET /postures/default
+func getDefaultPosture(c *gin.Context, state *common.State) {
+	_, defaultPosture, err := getPosturesAndDefault(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"defaultSourcePosture": defaultPosture})
+}
+
+// setDefaultPosture => PUT /postures/default
+// Expects JSON: { "defaultSourcePosture": [ "some expression", ... ] }
+func setDefaultPosture(c *gin.Context, state *common.State) {
+	var body struct {
+		DefaultSourcePosture []string `json:"defaultSourcePosture"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	// If user didn't pass defaultSourcePosture or set it to nil, treat as empty?
+	dsp := body.DefaultSourcePosture
+
+	postures, _, err := getPosturesAndDefault(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := savePosturesAndDefault(state, postures, dsp); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set default posture"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"defaultSourcePosture": dsp})
+}
+
+// deleteDefaultPosture => DELETE /postures/default
+func deleteDefaultPosture(c *gin.Context, state *common.State) {
+	postures, _, err := getPosturesAndDefault(state)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	// Setting it to nil or empty effectively deletes it
+	if err := savePosturesAndDefault(state, postures, nil); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete default posture"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "defaultSourcePosture removed"})
+}
+
+// -----------------------------------------------------------------------------
+// Internal storage format in state.Data["postures"] => map[string][]string
+//  - "posture:<NAME>" => []string (the named posture rules)
+//  - "defaultSourcePosture" => []string (the global default posture rules)
+// -----------------------------------------------------------------------------
+
+// getPosturesAndDefault => read map from state => parse out named postures + default
+func getPosturesAndDefault(state *common.State) (postureList []Posture, defaultPosture []string, err error) {
+	raw := state.GetValue("postures")
+	if raw == nil {
+		return []Posture{}, nil, nil
+	}
+	b, e := json.Marshal(raw)
+	if e != nil {
+		return nil, nil, e
+	}
+	var rawMap map[string][]string
+	if e := json.Unmarshal(b, &rawMap); e != nil {
+		return nil, nil, e
+	}
+
+	// Convert map => postureList
+	var out []Posture
+	var dsp []string
+	for k, v := range rawMap {
+		if k == "defaultSourcePosture" {
+			dsp = v
+			continue
+		}
+		// strip leading "posture:" if present
+		name := strings.TrimPrefix(k, "posture:")
+		out = append(out, Posture{
+			Name:  name,
+			Rules: v,
+		})
+	}
+	return out, dsp, nil
+}
+
+// savePosturesAndDefault => convert postureList + default => map => write to state.
+func savePosturesAndDefault(state *common.State, postures []Posture, defaultPosture []string) error {
+	m := make(map[string][]string)
+
+	// Insert named postures
+	for _, p := range postures {
+		key := p.Name
+		if !strings.HasPrefix(key, "posture:") {
+			key = "posture:" + key
+		}
+		m[key] = p.Rules
+	}
+
+	// Insert default posture if set
+	if len(defaultPosture) > 0 {
+		m["defaultSourcePosture"] = defaultPosture
+	}
+
+	return state.UpdateKeyAndSave("postures", m)
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `/hosts` and `/postures` endpoints with CRUD operations and default posture handling in `main.go`, `hosts.go`, and `postures.go`.
> 
>   - **Behavior**:
>     - Adds `/hosts` and `/postures` endpoints in `main.go` for managing hosts and postures.
>     - Supports CRUD operations for hosts and postures, including special handling for default postures.
>   - **Hosts**:
>     - Implements `RegisterRoutes` in `hosts.go` to handle `/hosts` endpoints.
>     - Provides functions for listing, creating, updating, and deleting hosts.
>   - **Postures**:
>     - Implements `RegisterRoutes` in `postures.go` to handle `/postures` endpoints.
>     - Provides functions for listing, creating, updating, and deleting postures, with special routes for default postures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lbrlabs%2Ftacl&utm_source=github&utm_medium=referral)<sup> for cb398685f6257386a2deaa7817289ddda0b9be57. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->