### PR TITLE
feat: add wildcard support for capability checks in TailscaleAuthMiddleware

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lbrlabs/tacl/pkg/acl/postures"
 	"github.com/lbrlabs/tacl/pkg/acl/settings"
 	"github.com/lbrlabs/tacl/pkg/acl/ssh"
+	"github.com/lbrlabs/tacl/pkg/cap"
 	"github.com/lbrlabs/tacl/pkg/common"
 	"go.uber.org/zap"
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `TailscaleAuthMiddleware` in `cap.go` to support wildcard capability checks for methods and endpoints using `matchStringListOrWildcard`.
> 
>   - **Behavior**:
>     - Enhance `TailscaleAuthMiddleware` in `cap.go` to support wildcard "*" in `Methods` and `Endpoints` for capability checks.
>     - Introduce `matchStringListOrWildcard` function in `cap.go` to handle wildcard logic.
>   - **Imports**:
>     - Add import for `github.com/lbrlabs/tacl/pkg/cap` in `main.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lbrlabs%2Ftacl&utm_source=github&utm_medium=referral)<sup> for f40e839c05b9e25acfe761e10813aaeb6d80394c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

Fixes #10 