### PR TITLE
feat: add UUID support for SSH rules and Terraform integration

### DIFF
--- a/pkg/acl/ssh/ssh.go
+++ b/pkg/acl/ssh/ssh.go
@@ -1,182 +1,230 @@
 package ssh
 
 import (
-	"encoding/json"
-	"net/http"
-	"strconv"
+    "encoding/json"
+    "net/http"
+    "strconv"
+    "time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/lbrlabs/tacl/pkg/common"
-	tsclient "github.com/tailscale/tailscale-client-go/v2" // where ACLSSH is defined
+    "github.com/gin-gonic/gin"
+    "github.com/google/uuid"
+    "github.com/lbrlabs/tacl/pkg/common"
 )
 
+// ACLSSH represents the user-facing SSH rule fields.
+type ACLSSH struct {
+    Action      string   `json:"action"`                // "accept" or "check"
+    Src         []string `json:"src,omitempty"`         // list of sources
+    Dst         []string `json:"dst,omitempty"`         // list of destinations
+    Users       []string `json:"users,omitempty"`       // list of SSH users
+    CheckPeriod string   `json:"checkPeriod,omitempty"` // optional, only for "check"
+    AcceptEnv   []string `json:"acceptEnv,omitempty"`   // optional, allow-list environment variables
+}
+
+// ExtendedSSHEntry wraps ACLSSH with a stable unique ID.
+type ExtendedSSHEntry struct {
+    ID string `json:"id"` // stable UUID for each SSH rule
+    ACLSSH
+}
+
 // RegisterRoutes wires up the SSH rules routes at /ssh.
-//
-// Example endpoints:
-//
-//	GET    /ssh         => list all SSH rules
-//	GET    /ssh/:index  => get one by index
-//	POST   /ssh         => create a new rule
-//	PUT    /ssh         => update rule by index in JSON
-//	DELETE /ssh         => delete rule by index in JSON
 func RegisterRoutes(r *gin.Engine, state *common.State) {
-	s := r.Group("/ssh")
-	{
-		s.GET("", func(c *gin.Context) {
-			listSSH(c, state)
-		})
-		s.GET("/:index", func(c *gin.Context) {
-			getSSHByIndex(c, state)
-		})
-		s.POST("", func(c *gin.Context) {
-			createSSH(c, state)
-		})
-		s.PUT("", func(c *gin.Context) {
-			updateSSH(c, state)
-		})
-		s.DELETE("", func(c *gin.Context) {
-			deleteSSH(c, state)
-		})
-	}
+    s := r.Group("/ssh")
+    {
+        s.GET("", func(c *gin.Context) {
+            listSSH(c, state)
+        })
+        // GET /ssh/:index => get by numeric index
+        s.GET("/:index", func(c *gin.Context) {
+            getSSHByIndex(c, state)
+        })
+        // POST /ssh => create (automatically generate ID)
+        s.POST("", func(c *gin.Context) {
+            createSSH(c, state)
+        })
+        // PUT /ssh => update by index in JSON
+        s.PUT("", func(c *gin.Context) {
+            updateSSH(c, state)
+        })
+        // DELETE /ssh => delete by index in JSON
+        s.DELETE("", func(c *gin.Context) {
+            deleteSSH(c, state)
+        })
+    }
 }
 
 // listSSH => GET /ssh
-// returns all ACLSSH entries
+// returns the entire slice of ExtendedSSHEntry
 func listSSH(c *gin.Context, state *common.State) {
-	rules, err := getSSHFromState(state)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
-		return
-	}
-	c.JSON(http.StatusOK, rules)
+    entries, err := getSSHFromState(state)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
+        return
+    }
+    c.JSON(http.StatusOK, entries)
 }
 
 // getSSHByIndex => GET /ssh/:index
+// fetches the ExtendedSSHEntry by array index
 func getSSHByIndex(c *gin.Context, state *common.State) {
-	indexStr := c.Param("index")
-	i, err := strconv.Atoi(indexStr)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid index"})
-		return
-	}
+    indexStr := c.Param("index")
+    i, err := strconv.Atoi(indexStr)
+    if err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid index"})
+        return
+    }
 
-	rules, err := getSSHFromState(state)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
-		return
-	}
+    entries, err := getSSHFromState(state)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
+        return
+    }
 
-	if i < 0 || i >= len(rules) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "SSH rule index out of range"})
-		return
-	}
-	c.JSON(http.StatusOK, rules[i])
+    if i < 0 || i >= len(entries) {
+        c.JSON(http.StatusNotFound, gin.H{"error": "SSH rule index out of range"})
+        return
+    }
+    c.JSON(http.StatusOK, entries[i])
 }
 
 // createSSH => POST /ssh
-// creates a new ACLSSH entry at the end of the slice
+// appends a new ExtendedSSHEntry (with auto-generated ID) to the slice
 func createSSH(c *gin.Context, state *common.State) {
-	var newRule tsclient.ACLSSH
-	if err := c.ShouldBindJSON(&newRule); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
+    var newRule ACLSSH
+    if err := c.ShouldBindJSON(&newRule); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    }
 
-	rules, err := getSSHFromState(state)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
-		return
-	}
+    // Basic validation
+    if newRule.Action != "accept" && newRule.Action != "check" {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid action. Must be 'accept' or 'check'."})
+        return
+    }
+    if newRule.Action == "check" {
+        if _, err := time.ParseDuration(newRule.CheckPeriod); err != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid checkPeriod. Must be a valid duration (e.g. '12h', '30m')."})
+            return
+        }
+    }
 
-	rules = append(rules, newRule)
-	if err := state.UpdateKeyAndSave("sshRules", rules); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save new SSH rule"})
-		return
-	}
-	c.JSON(http.StatusCreated, newRule)
+    entries, err := getSSHFromState(state)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
+        return
+    }
+
+    // Create new ExtendedSSHEntry with a generated UUID.
+    newEntry := ExtendedSSHEntry{
+        ID:     uuid.NewString(),
+        ACLSSH: newRule,
+    }
+
+    entries = append(entries, newEntry)
+    if err := state.UpdateKeyAndSave("sshRules", entries); err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save new SSH rule"})
+        return
+    }
+    c.JSON(http.StatusCreated, newEntry)
 }
 
 // updateSSH => PUT /ssh
-// user must provide JSON with an "index" and the new rule data
+// user must provide JSON with an "index" and the new rule data => { "index": 0, "rule": { ... } }
 func updateSSH(c *gin.Context, state *common.State) {
-	type updateRequest struct {
-		Index int             `json:"index"`
-		Rule  tsclient.ACLSSH `json:"rule"`
-	}
-	var req updateRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	if req.Index < 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid or missing 'index' field"})
-		return
-	}
+    type updateRequest struct {
+        Index int    `json:"index"`
+        Rule  ACLSSH `json:"rule"`
+    }
+    var req updateRequest
+    if err := c.ShouldBindJSON(&req); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    }
+    if req.Index < 0 {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid or missing 'index' field"})
+        return
+    }
 
-	rules, err := getSSHFromState(state)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
-		return
-	}
+    // Basic validation on the new rule
+    if req.Rule.Action != "accept" && req.Rule.Action != "check" {
+        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid action. Must be 'accept' or 'check'."})
+        return
+    }
+    if req.Rule.Action == "check" && req.Rule.CheckPeriod == "" {
+        req.Rule.CheckPeriod = "12h"
+    }
+    if req.Rule.Action == "check" {
+        if _, err := time.ParseDuration(req.Rule.CheckPeriod); err != nil {
+            c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid checkPeriod. Must be a valid duration."})
+            return
+        }
+    }
 
-	if req.Index >= len(rules) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "SSH rule index out of range"})
-		return
-	}
+    entries, err := getSSHFromState(state)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
+        return
+    }
 
-	rules[req.Index] = req.Rule
+    if req.Index >= len(entries) {
+        c.JSON(http.StatusNotFound, gin.H{"error": "SSH rule index out of range"})
+        return
+    }
 
-	if err := state.UpdateKeyAndSave("sshRules", rules); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update SSH rule"})
-		return
-	}
-	c.JSON(http.StatusOK, req.Rule)
+    // Keep the existing ID the same, only update the embedded ACLSSH fields
+    entries[req.Index].ACLSSH = req.Rule
+
+    if err := state.UpdateKeyAndSave("sshRules", entries); err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update SSH rule"})
+        return
+    }
+    c.JSON(http.StatusOK, entries[req.Index])
 }
 
 // deleteSSH => DELETE /ssh
-// user must provide JSON with "index" to remove from the slice
+// user must provide JSON with "index" => { "index": 0 }
 func deleteSSH(c *gin.Context, state *common.State) {
-	type deleteRequest struct {
-		Index int `json:"index"`
-	}
-	var req deleteRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
+    type deleteRequest struct {
+        Index int `json:"index"`
+    }
+    var req deleteRequest
+    if err := c.ShouldBindJSON(&req); err != nil {
+        c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+        return
+    }
 
-	rules, err := getSSHFromState(state)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
-		return
-	}
+    entries, err := getSSHFromState(state)
+    if err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to parse SSH rules"})
+        return
+    }
 
-	if req.Index < 0 || req.Index >= len(rules) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "SSH rule index out of range"})
-		return
-	}
+    if req.Index < 0 || req.Index >= len(entries) {
+        c.JSON(http.StatusNotFound, gin.H{"error": "SSH rule index out of range"})
+        return
+    }
 
-	rules = append(rules[:req.Index], rules[req.Index+1:]...)
-	if err := state.UpdateKeyAndSave("sshRules", rules); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete SSH rule"})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"message": "SSH rule deleted"})
+    entries = append(entries[:req.Index], entries[req.Index+1:]...)
+    if err := state.UpdateKeyAndSave("sshRules", entries); err != nil {
+        c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete SSH rule"})
+        return
+    }
+    c.JSON(http.StatusOK, gin.H{"message": "SSH rule deleted"})
 }
 
-// getSSHFromState => re-marshal state.Data["sshRules"] into []ACLSSH
-func getSSHFromState(state *common.State) ([]tsclient.ACLSSH, error) {
-	raw := state.GetValue("sshRules")
-	if raw == nil {
-		return []tsclient.ACLSSH{}, nil
-	}
-	b, err := json.Marshal(raw)
-	if err != nil {
-		return nil, err
-	}
-	var rules []tsclient.ACLSSH
-	if err := json.Unmarshal(b, &rules); err != nil {
-		return nil, err
-	}
-	return rules, nil
+// getSSHFromState => re-marshal state.Data["sshRules"] into []ExtendedSSHEntry
+func getSSHFromState(state *common.State) ([]ExtendedSSHEntry, error) {
+    raw := state.GetValue("sshRules")
+    if raw == nil {
+        return []ExtendedSSHEntry{}, nil
+    }
+    b, err := json.Marshal(raw)
+    if err != nil {
+        return nil, err
+    }
+    var entries []ExtendedSSHEntry
+    if err := json.Unmarshal(b, &entries); err != nil {
+        return nil, err
+    }
+    return entries, nil
 }

--- a/terraform/provider/ssh_data_source.go
+++ b/terraform/provider/ssh_data_source.go
@@ -1,0 +1,196 @@
+package provider
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "strconv"
+
+    "github.com/hashicorp/terraform-plugin-framework/datasource"
+    "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+    "github.com/hashicorp/terraform-plugin-framework/types"
+    "github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// Ensure interface compliance for Terraform Plugin Framework.
+var (
+    _ datasource.DataSource              = &sshDataSource{}
+    _ datasource.DataSourceWithConfigure = &sshDataSource{}
+)
+
+// NewSSHDataSource => constructor for "tacl_ssh" data source.
+func NewSSHDataSource() datasource.DataSource {
+    return &sshDataSource{}
+}
+
+// sshDataSource => fetches a single SSH rule by integer index.
+type sshDataSource struct {
+    httpClient *http.Client
+    endpoint   string
+}
+
+// sshDataSourceModel => local struct for reading the SSH rule by index
+type sshDataSourceModel struct {
+    // We'll store the index in "id" or a separate field—mirroring your ACL DS approach that used ID as index.
+    ID          types.String   `tfsdk:"id"` // index as string
+    Action      types.String   `tfsdk:"action"`
+    Src         []types.String `tfsdk:"src"`
+    Dst         []types.String `tfsdk:"dst"`
+    Users       []types.String `tfsdk:"users"`
+    CheckPeriod types.String   `tfsdk:"check_period"`
+    AcceptEnv   []types.String `tfsdk:"accept_env"`
+}
+
+// ----- 1) Configure / 2) Metadata / 3) Schema -----
+
+func (d *sshDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+    if req.ProviderData == nil {
+        return
+    }
+    provider, ok := req.ProviderData.(*taclProvider)
+    if !ok {
+        return
+    }
+    d.httpClient = provider.httpClient
+    d.endpoint = provider.endpoint
+}
+
+func (d *sshDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+    resp.TypeName = req.ProviderTypeName + "_ssh"
+}
+
+func (d *sshDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        Description: "Data source for reading a single SSH rule by integer index in TACL’s array.",
+        Attributes: map[string]schema.Attribute{
+            "id": schema.StringAttribute{
+                Description: "Index of the SSH rule in TACL’s array (e.g. '0').",
+                Required:    true,
+            },
+            "action": schema.StringAttribute{
+                Description: "SSH action: 'accept' or 'check'.",
+                Computed:    true,
+            },
+            "src": schema.ListAttribute{
+                Description: "Sources for the SSH rule.",
+                Computed:    true,
+                ElementType: types.StringType,
+            },
+            "dst": schema.ListAttribute{
+                Description: "Destinations for the SSH rule.",
+                Computed:    true,
+                ElementType: types.StringType,
+            },
+            "users": schema.ListAttribute{
+                Description: "SSH users allowed.",
+                Computed:    true,
+                ElementType: types.StringType,
+            },
+            "check_period": schema.StringAttribute{
+                Description: "Duration (e.g. '12h') for check actions.",
+                Computed:    true,
+            },
+            "accept_env": schema.ListAttribute{
+                Description: "Environment variable patterns allowed.",
+                Computed:    true,
+                ElementType: types.StringType,
+            },
+        },
+    }
+}
+
+// ----- 4) Read -----
+
+func (d *sshDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+    var data sshDataSourceModel
+    diags := req.Config.Get(ctx, &data)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // Interpret the "id" attribute as the numeric index
+    idxStr := data.ID.ValueString()
+    idx, err := strconv.Atoi(idxStr)
+    if err != nil {
+        resp.Diagnostics.AddError("Invalid index", fmt.Sprintf("Cannot parse '%s' as integer", idxStr))
+        return
+    }
+
+    // GET /ssh/:index
+    getURL := fmt.Sprintf("%s/ssh/%d", d.endpoint, idx)
+    tflog.Debug(ctx, "Reading SSH data source by index", map[string]interface{}{
+        "url":   getURL,
+        "index": idx,
+    })
+
+    respBody, err := doSSHIndexRequest(ctx, d.httpClient, http.MethodGet, getURL, nil)
+    if err != nil {
+        if IsNotFound(err) {
+            resp.Diagnostics.AddWarning("Not found", fmt.Sprintf("No SSH rule at index %d", idx))
+            return
+        }
+        resp.Diagnostics.AddError("Error reading SSH data source", err.Error())
+        return
+    }
+
+    // The server presumably returns the raw TaclSSHEntry shape for that index
+    // (or you can define a dedicated shape).
+    var sshRule TaclSSHEntry
+    if err := json.Unmarshal(respBody, &sshRule); err != nil {
+        resp.Diagnostics.AddError("JSON parse error", err.Error())
+        return
+    }
+
+    // Populate Terraform state
+    data.Action = types.StringValue(sshRule.Action)
+    data.Src = toTerraformStringSlice(sshRule.Src)
+    data.Dst = toTerraformStringSlice(sshRule.Dst)
+    data.Users = toTerraformStringSlice(sshRule.Users)
+    data.CheckPeriod = types.StringValue(sshRule.CheckPeriod)
+    data.AcceptEnv = toTerraformStringSlice(sshRule.AcceptEnv)
+
+    diags = resp.State.Set(ctx, &data)
+    resp.Diagnostics.Append(diags...)
+}
+
+// doSSHIndexRequest => simpler than resource calls, but same idea
+func doSSHIndexRequest(ctx context.Context, client *http.Client, method, url string, payload interface{}) ([]byte, error) {
+    var body io.Reader
+    if payload != nil {
+        data, err := json.Marshal(payload)
+        if err != nil {
+            return nil, fmt.Errorf("failed to marshal payload: %w", err)
+        }
+        body = bytes.NewBuffer(data)
+    }
+
+    req, err := http.NewRequestWithContext(ctx, method, url, body)
+    if err != nil {
+        return nil, fmt.Errorf("failed to create request: %w", err)
+    }
+    req.Header.Set("Content-Type", "application/json")
+
+    res, err := client.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("request error: %w", err)
+    }
+    defer res.Body.Close()
+
+    if res.StatusCode == 404 {
+        return nil, &NotFoundError{Message: "SSH rule not found"}
+    }
+    if res.StatusCode >= 300 {
+        msg, _ := io.ReadAll(res.Body)
+        return nil, fmt.Errorf("TACL returned %d: %s", res.StatusCode, string(msg))
+    }
+
+    respBody, err := io.ReadAll(res.Body)
+    if err != nil {
+        return nil, fmt.Errorf("failed to read response: %w", err)
+    }
+    return respBody, nil
+}

--- a/terraform/provider/ssh_resource.go
+++ b/terraform/provider/ssh_resource.go
@@ -1,0 +1,397 @@
+package provider
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+
+    "github.com/hashicorp/terraform-plugin-framework/resource"
+    "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+    "github.com/hashicorp/terraform-plugin-framework/types"
+    "github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+// TaclSSHEntry => Represents the user-facing fields for an SSH rule.
+type TaclSSHEntry struct {
+    Action      string   `json:"action"`      // "accept" or "check"
+    Src         []string `json:"src"`         // sources
+    Dst         []string `json:"dst"`         // destinations
+    Users       []string `json:"users"`       // SSH users
+    CheckPeriod string   `json:"checkPeriod"` // optional duration, e.g. "12h"
+    AcceptEnv   []string `json:"acceptEnv"`   // optional environment vars
+}
+
+// TaclSSHResponse => The server’s extended SSH shape: stable ID + fields above
+type TaclSSHResponse struct {
+    ID           string       `json:"id"` // stable UUID from TACL
+    TaclSSHEntry `json:",inline"`
+}
+
+// Ensure interface compliance with Terraform plugin framework.
+var (
+    _ resource.Resource              = &sshResource{}
+    _ resource.ResourceWithConfigure = &sshResource{}
+)
+
+// NewSSHResource => constructor for "tacl_ssh" resource
+func NewSSHResource() resource.Resource {
+    return &sshResource{}
+}
+
+// sshResource => main struct implementing Resource
+type sshResource struct {
+    httpClient *http.Client
+    endpoint   string
+}
+
+// sshResourceModel => Terraform schema for storing the user’s config + the ID
+type sshResourceModel struct {
+    ID           types.String   `tfsdk:"id"`
+    Action       types.String   `tfsdk:"action"`
+    Src          []types.String `tfsdk:"src"`
+    Dst          []types.String `tfsdk:"dst"`
+    Users        []types.String `tfsdk:"users"`
+    CheckPeriod  types.String   `tfsdk:"check_period"`
+    AcceptEnv    []types.String `tfsdk:"accept_env"`
+}
+
+
+func (r *sshResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+    if req.ProviderData == nil {
+        return
+    }
+    provider, ok := req.ProviderData.(*taclProvider)
+    if !ok {
+        return
+    }
+    r.httpClient = provider.httpClient
+    r.endpoint = provider.endpoint
+}
+
+func (r *sshResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+    resp.TypeName = req.ProviderTypeName + "_ssh"
+}
+
+func (r *sshResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema = schema.Schema{
+        Description: "Manages a single SSH rule by stable ID in TACL’s /ssh.",
+        Attributes: map[string]schema.Attribute{
+            "id": schema.StringAttribute{
+                Description: "TACL's stable UUID for this SSH rule.",
+                Computed:    true,
+            },
+            "action": schema.StringAttribute{
+                Description: "SSH action, e.g. 'accept' or 'check'.",
+                Required:    true,
+            },
+            "src": schema.ListAttribute{
+                Description: "List of source specifications (e.g. tags, CIDRs).",
+                Required:    true,
+                ElementType: types.StringType,
+            },
+            "dst": schema.ListAttribute{
+                Description: "List of destination specifications (e.g. host:port).",
+                Required:    true,
+                ElementType: types.StringType,
+            },
+            "users": schema.ListAttribute{
+                Description: "List of SSH users allowed.",
+                Required:    true,
+                ElementType: types.StringType,
+            },
+            "check_period": schema.StringAttribute{
+                Description: "Optional duration for 'check' actions, e.g. '12h'.",
+                Optional:    true,
+            },
+            "accept_env": schema.ListAttribute{
+                Description: "Optional list of environment variable patterns to allow.",
+                Optional:    true,
+                ElementType: types.StringType,
+            },
+        },
+    }
+}
+
+// ----------------------------------------------------------------------------
+// 4) Create
+// ----------------------------------------------------------------------------
+
+func (r *sshResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+    // 1. Read plan data
+    var plan sshResourceModel
+    diags := req.Plan.Get(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // 2. Convert plan to JSON for TACL => TaclSSHEntry
+    payload := TaclSSHEntry{
+        Action:      plan.Action.ValueString(),
+        Src:         toStringSlice(plan.Src),
+        Dst:         toStringSlice(plan.Dst),
+        Users:       toStringSlice(plan.Users),
+        CheckPeriod: plan.CheckPeriod.ValueString(),
+        AcceptEnv:   toStringSlice(plan.AcceptEnv),
+    }
+
+    // 3. POST /ssh => create a new item with a server-generated ID
+    postURL := fmt.Sprintf("%s/ssh", r.endpoint)
+    tflog.Debug(ctx, "Creating SSH rule", map[string]interface{}{
+        "url":     postURL,
+        "payload": payload,
+    })
+
+    body, err := doSSHIDRequest(ctx, r.httpClient, http.MethodPost, postURL, payload)
+    if err != nil {
+        resp.Diagnostics.AddError("Create SSH error", err.Error())
+        return
+    }
+
+    // 4. Parse response => TaclSSHResponse
+    var created TaclSSHResponse
+    if e := json.Unmarshal(body, &created); e != nil {
+        resp.Diagnostics.AddError("Parse create response error", e.Error())
+        return
+    }
+
+    // 5. Save ID + other fields to state
+    plan.ID = types.StringValue(created.ID)
+    plan.Action = types.StringValue(created.Action)
+    plan.Src = toTerraformStringSlice(created.Src)
+    plan.Dst = toTerraformStringSlice(created.Dst)
+    plan.Users = toTerraformStringSlice(created.Users)
+    plan.CheckPeriod = types.StringValue(created.CheckPeriod)
+    plan.AcceptEnv = toTerraformStringSlice(created.AcceptEnv)
+
+    diags = resp.State.Set(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+}
+
+// ----------------------------------------------------------------------------
+// 5) Read
+// ----------------------------------------------------------------------------
+
+func (r *sshResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+    // 1. Get current state (need the ID)
+    var state sshResourceModel
+    diags := req.State.Get(ctx, &state)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // 2. If ID is empty => remove
+    if state.ID.IsNull() || state.ID.ValueString() == "" {
+        resp.State.RemoveResource(ctx)
+        return
+    }
+    id := state.ID.ValueString()
+
+    // 3. GET /ssh/:id
+    getURL := fmt.Sprintf("%s/ssh/%s", r.endpoint, id)
+    tflog.Debug(ctx, "Reading SSH rule by ID", map[string]interface{}{
+        "url": getURL,
+        "id":  id,
+    })
+
+    body, err := doSSHIDRequest(ctx, r.httpClient, http.MethodGet, getURL, nil)
+    if err != nil {
+        if isNotFound(err) {
+            // TACL says it's gone => remove from TF
+            resp.State.RemoveResource(ctx)
+            return
+        }
+        resp.Diagnostics.AddError("Read SSH error", err.Error())
+        return
+    }
+
+    var fetched TaclSSHResponse
+    if e := json.Unmarshal(body, &fetched); e != nil {
+        resp.Diagnostics.AddError("Parse read response error", e.Error())
+        return
+    }
+
+    // 4. Update state with fetched data
+    state.ID = types.StringValue(fetched.ID)
+    state.Action = types.StringValue(fetched.Action)
+    state.Src = toTerraformStringSlice(fetched.Src)
+    state.Dst = toTerraformStringSlice(fetched.Dst)
+    state.Users = toTerraformStringSlice(fetched.Users)
+    state.CheckPeriod = types.StringValue(fetched.CheckPeriod)
+    state.AcceptEnv = toTerraformStringSlice(fetched.AcceptEnv)
+
+    diags = resp.State.Set(ctx, &state)
+    resp.Diagnostics.Append(diags...)
+}
+
+// ----------------------------------------------------------------------------
+// 6) Update
+// ----------------------------------------------------------------------------
+
+func (r *sshResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+    // 1. Old state => preserve ID
+    var oldState sshResourceModel
+    diags := req.State.Get(ctx, &oldState)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // 2. New plan => user config
+    var plan sshResourceModel
+    diags = req.Plan.Get(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    // 3. Merge ID
+    plan.ID = oldState.ID
+    id := plan.ID.ValueString()
+    if id == "" {
+        // no ID => cannot update
+        resp.State.RemoveResource(ctx)
+        return
+    }
+
+    // 4. Convert plan to TaclSSHEntry
+    input := TaclSSHEntry{
+        Action:      plan.Action.ValueString(),
+        Src:         toStringSlice(plan.Src),
+        Dst:         toStringSlice(plan.Dst),
+        Users:       toStringSlice(plan.Users),
+        CheckPeriod: plan.CheckPeriod.ValueString(),
+        AcceptEnv:   toStringSlice(plan.AcceptEnv),
+    }
+
+    // 5. PUT /ssh => typically something like { "id": "<uuid>", "action": "...", ... }
+    //    or { "id":"<uuid>", "entry": { ... } }
+    putURL := fmt.Sprintf("%s/ssh", r.endpoint)
+    payload := map[string]interface{}{
+        "id":    id,
+        "action":      input.Action,
+        "src":         input.Src,
+        "dst":         input.Dst,
+        "users":       input.Users,
+        "checkPeriod": input.CheckPeriod,
+        "acceptEnv":   input.AcceptEnv,
+    }
+
+    tflog.Debug(ctx, "Updating SSH rule by ID", map[string]interface{}{
+        "url":     putURL,
+        "payload": payload,
+    })
+
+    body, err := doSSHIDRequest(ctx, r.httpClient, http.MethodPut, putURL, payload)
+    if err != nil {
+        if isNotFound(err) {
+            // TACL says it's gone => remove from state
+            resp.State.RemoveResource(ctx)
+            return
+        }
+        resp.Diagnostics.AddError("Update SSH error", err.Error())
+        return
+    }
+
+    var updated TaclSSHResponse
+    if e := json.Unmarshal(body, &updated); e != nil {
+        resp.Diagnostics.AddError("Parse update response error", e.Error())
+        return
+    }
+
+    // 6. Merge updated data back
+    plan.ID = types.StringValue(updated.ID)
+    plan.Action = types.StringValue(updated.Action)
+    plan.Src = toTerraformStringSlice(updated.Src)
+    plan.Dst = toTerraformStringSlice(updated.Dst)
+    plan.Users = toTerraformStringSlice(updated.Users)
+    plan.CheckPeriod = types.StringValue(updated.CheckPeriod)
+    plan.AcceptEnv = toTerraformStringSlice(updated.AcceptEnv)
+
+    // 7. Save final
+    diags = resp.State.Set(ctx, &plan)
+    resp.Diagnostics.Append(diags...)
+}
+
+// ----------------------------------------------------------------------------
+// 7) Delete
+// ----------------------------------------------------------------------------
+
+func (r *sshResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+    var data sshResourceModel
+    diags := req.State.Get(ctx, &data)
+    resp.Diagnostics.Append(diags...)
+    if resp.Diagnostics.HasError() {
+        return
+    }
+
+    id := data.ID.ValueString()
+    if id == "" {
+        // already removed
+        resp.State.RemoveResource(ctx)
+        return
+    }
+
+    // DELETE => /ssh => { "id":"<uuid>" }
+    delURL := fmt.Sprintf("%s/ssh", r.endpoint)
+    payload := map[string]string{"id": id}
+
+    tflog.Debug(ctx, "Deleting SSH rule by ID", map[string]interface{}{
+        "url":     delURL,
+        "payload": payload,
+    })
+
+    _, err := doSSHIDRequest(ctx, r.httpClient, http.MethodDelete, delURL, payload)
+    if err != nil {
+        if isNotFound(err) {
+            // already gone
+        } else {
+            resp.Diagnostics.AddError("Delete SSH error", err.Error())
+            return
+        }
+    }
+
+    resp.State.RemoveResource(ctx)
+}
+
+// ----------------------------------------------------------------------------
+// Helper HTTP logic
+// ----------------------------------------------------------------------------
+
+// doSSHIDRequest => helper for create/read/update/delete calls.
+func doSSHIDRequest(ctx context.Context, client *http.Client, method, url string, payload interface{}) ([]byte, error) {
+    var body io.Reader
+    if payload != nil {
+        b, err := json.Marshal(payload)
+        if err != nil {
+            return nil, fmt.Errorf("failed to marshal payload: %w", err)
+        }
+        body = bytes.NewBuffer(b)
+    }
+
+    req, err := http.NewRequestWithContext(ctx, method, url, body)
+    if err != nil {
+        return nil, fmt.Errorf("request creation error: %w", err)
+    }
+    req.Header.Set("Content-Type", "application/json")
+
+    resp, err := client.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("SSH ID request error: %w", err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode == 404 {
+        return nil, &NotFoundError{Message: "SSH rule not found"}
+    }
+    if resp.StatusCode >= 300 {
+        msg, _ := io.ReadAll(resp.Body)
+        return nil, fmt.Errorf("TACL returned %d: %s", resp.StatusCode, string(msg))
+    }
+
+    return io.ReadAll(resp.Body)
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds UUID support for SSH rules in Go and introduces Terraform data source and resource for managing these rules.
> 
>   - **Behavior**:
>     - Introduces `ExtendedSSHEntry` with UUIDs in `ssh.go` for SSH rules.
>     - Adds validation for `action` and `checkPeriod` in `createSSH` and `updateSSH`.
>     - Updates `getSSHFromState` to handle `ExtendedSSHEntry`.
>   - **Terraform Provider**:
>     - Adds `ssh_data_source.go` for reading SSH rules by index.
>     - Adds `ssh_resource.go` for managing SSH rules by UUID.
>     - Implements CRUD operations in `ssh_resource.go` using HTTP requests to `/ssh` endpoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lbrlabs%2Ftacl&utm_source=github&utm_medium=referral)<sup> for 637700a2deb46513515be32364d34c8349601e78. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->